### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,11 +1,11 @@
 WeatherMeters	KEYWORD1
 attach	KEYWORD2
-debug   KEYWORD2
-adcToDir   KEYWORD2
-getDir  KEYWORD2
+debug	KEYWORD2
+adcToDir	KEYWORD2
+getDir	KEYWORD2
 getSpeed	KEYWORD2
 getRain	KEYWORD2
 intAnemometer	KEYWORD2
 intRaingauge	KEYWORD2
-timer KEYWORD2
-reset KEYWORD2
+timer	KEYWORD2
+reset	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords